### PR TITLE
Decrease the plugin initialization priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Decreased the plugin initialization priority to *1000* to allow various dependencies to execute before RediPress.
+- The index creation is now run on the `init` hook with a priority of *1000*. This allow various dependencies to execute before RediPress indexing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- This changelog adhering to the 'keep a changelog' standard.
+
+### Changed
+
+- Decreased the plugin initialization priority to *1000* to allow various dependencies to execute before RediPress.

--- a/src/RediPress.php
+++ b/src/RediPress.php
@@ -47,7 +47,7 @@ class RediPress {
         $this->plugin = $plugin;
 
         // Initialize plugin functionalities in proper hook
-        add_action( 'init', [ $this, 'init' ], 1 );
+        add_action( 'init', [ $this, 'init' ], 1000 );
 
         // Add DustPress partials directory
         add_filter( 'dustpress/partials', function( $partials ) {

--- a/src/RediPress.php
+++ b/src/RediPress.php
@@ -47,7 +47,7 @@ class RediPress {
         $this->plugin = $plugin;
 
         // Initialize plugin functionalities in proper hook
-        add_action( 'init', [ $this, 'init' ], 1000 );
+        add_action( 'init', [ $this, 'init' ], 1 );
 
         // Add DustPress partials directory
         add_filter( 'dustpress/partials', function( $partials ) {
@@ -154,7 +154,9 @@ class RediPress {
         }
         else {
             // Initialize indexing features, we have everything we need to have here.
-            new Index( $this->connection );
+            add_action( 'init', function() {
+                new Index( $this->connection );
+            }, 1000 );
 
             return true;
         }


### PR DESCRIPTION
### Added

 - A changelog adhering to the 'keep a changelog' standard.

### Changed

 - Decreased the plugin initialization priority to *1000* to allow various dependencies to execute before RediPress.