### PR TITLE
Maybe serialize additional fields while creating the index

### DIFF
--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -366,6 +366,8 @@ class Index {
             return ! is_null( $item );
         });
 
+        $additions = array_map( 'maybe_serialize', $additions );
+
         $search_index = [];
         $tax          = [];
 


### PR DESCRIPTION
Indexing crashes if the additional data is not scalar. Running the values through `maybe_serialize` fixes this issue.