### PR TITLE
Polylang - multisite main query fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix Polylang's localized main queries on multisites by using the language slug in term queries instead of the language term id.
+
 ## [1.3.1] - 2020-04-28
 
 ### Fixed

--- a/src/External/Polylang.php
+++ b/src/External/Polylang.php
@@ -14,8 +14,74 @@ class Polylang {
      * Constructor
      */
     public function __construct() {
+        // Filter the query before RediPress to handle localizations.
+        add_filter( 'posts_pre_query', [ $this, 'posts_pre_query' ], 9, 2 );
         // Add the query var filter
         add_filter( 'redipress/query_vars', [ $this, 'add_query_var' ], 10, 1 );
+    }
+
+    /**
+     * Filter WordPress posts requests before RediPress.
+     *
+     * This fixes the main query on multisites where the main query
+     * is set to query posts from multiple sites.
+     *
+     * @param array|null $posts An empty array of posts.
+     * @param \WP_Query  $query The WP_Query object.
+     * @return array Results or null if no results.
+     */
+    public function posts_pre_query( ?array $posts, \WP_Query $query ) : ?array {
+        if ( method_exists( $query, 'is_main_query' ) && $query->is_main_query() ) {
+            $blog_id  = \get_current_blog_id();
+            $blog_var = $query->get( 'blog' );
+
+            // If querying from all blogs or
+            // the blog array contains more than just the current blog id or
+            // the blog id doesn't match the current one.
+            if (
+                $blog_var === 'all' ||
+                (
+                    is_array( $blog_var ) &&
+                    count( [ $blog_id ] + $blog_var ) > 1
+                ) ||
+                (
+                    is_scalar( $blog_var ) &&
+                    intval( $blog_var ) !== $blog_id
+                )
+            ) {
+                $tax_queries = $query->get( 'tax_query' ) ?? [];
+
+                if ( empty( $tax_queries ) ) {
+                    return $posts;
+                }
+
+                // Find the PLL language query and replace the id with the slug.
+                foreach ( $tax_queries as $idx => $tax_query ) {
+                    $taxonomy = $tax_query['taxonomy'] ?? '';
+                    $field    = $tax_query['field'] ?? '';
+
+                    if ( $taxonomy === 'language' && $field === 'term_taxonomy_id' ) {
+                        $term      = \get_term( $tax_query['terms'] );
+
+                        // Convert the id query to a slug query.
+                        $slug_query = [
+                            'taxonomy' => 'language',
+                            'field'    => 'slug', // Since WP 3.5
+                            'terms'    => [ $term->slug ?? '' ],
+                            'operator' => 'IN',
+                        ];
+
+                        // Replace the query.
+                        $tax_queries[ $idx ] = $slug_query;
+                    }
+                }
+
+                // Recreate the tax queries.
+                $query->tax_query = new \WP_Tax_Query( $tax_queries );
+            }
+        }
+
+        return $posts;
     }
 
     /**

--- a/src/External/Polylang.php
+++ b/src/External/Polylang.php
@@ -66,7 +66,7 @@ class Polylang {
                         // Convert the id query to a slug query.
                         $slug_query = [
                             'taxonomy' => 'language',
-                            'field'    => 'slug', // Since WP 3.5
+                            'field'    => 'slug',
                             'terms'    => [ $term->slug ?? '' ],
                             'operator' => 'IN',
                         ];


### PR DESCRIPTION
### Fixed
- Fix Polylang's localized main queries on multisites by using the language slug in term queries instead of the language term id.