### PR TITLE
Delete posts from index by blog_id and post_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [delete-by-post_-type] - 2021-02-25
+- Added cli command `wp redipress delete` to delete posts by blog_id and post_type.
+
 ## [1.9.1] - 2021-02-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -237,13 +237,14 @@ RediPress supports Polylang out of the box. Other multi-language plugins may req
 If you run into problems you can try dropping all indeces by running `wp redipress drop`. After this re-index.
 
 ## WP-CLI
+### command: wp redipress delete
 
-### Delete posts from the index
+description: Delete posts from the index by the arguments.
+arguments:
+- `document field:` Any field from the document that should match the given value.
+- `limit:` If not defined the default value is 100.
 
-If you need to delete posts from the index by `blog_id` or `post_type` then you can use cli command `wp redipress delete`.
-Limit for the delete is `100` by default but you can change that with a parameter `--limit`.
-
-#### Example usage
+example usage:
 ```bash
-wp redipress delete --blog_id=1 --post_type=post --limit=500
+wp redipress delete --blog_id=1 --post_type=article --limit=500
 ```

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ If you run into problems you can try dropping all indeces by running `wp redipre
 ## Delete posts from the index
 
 If you need to delete posts from the index by `blog_id` or `post_type` then you can use cli command `wp redipress delete`.
-Limit for the delete is by default `100` but you can change that with parameter `--limit`.
+Limit for the delete is `100` by default but you can change that with a parameter `--limit`.
 
 ### Example usage
 ```bash

--- a/README.md
+++ b/README.md
@@ -234,3 +234,13 @@ RediPress supports Polylang out of the box. Other multi-language plugins may req
 ## Troubleshooting
 
 If you run into problems you can try dropping all indeces by running `wp redipress drop`. After this re-index.
+
+## Delete posts from the index
+
+If you need to delete posts from the index by `blog_id` or `post_type` then you can use cli command `wp redipress delete`.
+Limit for the delete is by default `100` but you can change that with parameter `--limit`.
+
+### Example usage
+```bash
+wp redipress delete --blog_id=1 --post_type=post --limit=500
+```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ RediPress is also built with extensive amount of hooks and filters to customize 
   - [Advanced Custom Fields](#advanced-custom-fields)
   - [Polylang](#polylang)
 - [Troubleshooting](#troubleshooting)
+- [WP-CLI](#WP-CLI)
 
 <!-- /code_chunk_output -->
 
@@ -235,12 +236,14 @@ RediPress supports Polylang out of the box. Other multi-language plugins may req
 
 If you run into problems you can try dropping all indeces by running `wp redipress drop`. After this re-index.
 
-## Delete posts from the index
+## WP-CLI
+
+### Delete posts from the index
 
 If you need to delete posts from the index by `blog_id` or `post_type` then you can use cli command `wp redipress delete`.
 Limit for the delete is `100` by default but you can change that with a parameter `--limit`.
 
-### Example usage
+#### Example usage
 ```bash
 wp redipress delete --blog_id=1 --post_type=post --limit=500
 ```

--- a/src/CLI/Delete.php
+++ b/src/CLI/Delete.php
@@ -31,34 +31,16 @@ class Delete implements Command {
      */
     public function run( array $args = [], array $assoc_args = [] ) : bool {
 
-        // Only these arguments will be used.
-        $allowed_args = [
-            'blog_id',
-            'post_type',
-        ];
-
-        // Loop thourgh arguments and set allowed args to $query_vars.
-        if ( ! empty( $assoc_args ) && is_array( $assoc_args ) ) {
-            foreach ( $assoc_args as $key => $value ) {
-
-                // If parameter is allowed and not empty value.
-                if ( in_array( $key, $allowed_args ) && ! empty( $value ) ) {
-
-                    $query_vars[ $key ] = $value;
-                }
-            }
-        }
-
         // Default limit to 100.
         $limit = $assoc_args['limit'] ?? '100';
 
         // Blog_id and post_type.
-        if ( ! empty( $query_vars ) ) {
+        if ( ! empty( $assoc_args ) ) {
 
-            return $this->delete_posts( $query_vars, $limit );
+            return $this->delete_posts( $assoc_args, $limit );
         }
 
-        WP_CLI::error( 'Delete didn\'t execute. Please insert some of these parameters: ' . implode( ' ', $allowed_args ) );
+        WP_CLI::error( 'Delete didn\'t execute. Please insert some parameter.' );
 
         return false;
     }

--- a/src/CLI/Delete.php
+++ b/src/CLI/Delete.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * RediPress CLI delete command.
+ */
+
+namespace Geniem\RediPress\CLI;
+
+use WP_CLI;
+
+/**
+ * RediPress CLI delete command class.
+ */
+class Delete implements Command {
+
+    /**
+     * Class constructor.
+     */
+    public function __construct() {
+
+        // Get RediPress settings.
+        $this->client = apply_filters( 'redipress/client', null );
+        $this->index  = \Geniem\RediPress\Settings::get( 'index' );
+    }
+
+    /**
+     * The command itself.
+     *
+     * @param array $args The command parameters.
+     * @param array $assoc_args The optional command parameters.
+     * @return boolean
+     */
+    public function run( array $args = [], array $assoc_args = [] ) : bool {
+
+        // Safely get all the parameters.
+        $args = [
+            'blog_id'   => $assoc_args['blog_id'] ?? '',
+            'post_type' => $assoc_args['post_type'] ?? '',
+            'limit'     => $assoc_args['limit'] ?? '50',
+        ];
+
+        // Blog_id and post_type.
+        if ( ! empty( $args['blog_id'] ) || ! empty( $args['post_type'] ) || ! empty( $args['limit'] ) ) {
+
+            return $this->delete_posts( $args );
+        }
+
+        WP_CLI::error( 'Delete didn\'t execute' );
+
+        return false;
+    }
+
+    /**
+     * Index single post
+     *
+     * @param int $args The query args.
+     * @return bool
+     */
+    public function delete_posts( $args ) {
+
+        // Get the posts.
+        // Do the RediSearch query.
+        $posts = $this->client->raw_command(
+            'FT.SEARCH',
+            [
+                $this->index,
+                $this->build_where( $args ),
+                'RETURN',
+                1,
+                'post_id',
+                'LIMIT',
+                '0', // Limit from
+                $args['limit'], // Limit max
+            ],
+        );
+
+        // We need to get indexes of the doc_ids to be removed
+        $doc_id_indexes = $this->get_valid_doc_id_indexes( $posts );
+
+        $removed_doc_ids = [];
+
+        // Loop through doc_ids to be removed and
+        // do the delete from redisearch index.
+        if ( ! empty( $doc_id_indexes ) && is_array( $doc_id_indexes ) ) {
+            foreach ( $doc_id_indexes as $doc_id_index ) {
+
+                $doc_id = $posts[ $doc_id_index ];
+
+                $this->delete_index( $doc_id );
+                $removed_doc_ids[] = $doc_id;
+            }
+        }
+        // Fail.
+        else {
+            WP_CLI::error( 'There wasn\'t anything to delete' );
+        }
+
+        // Success message.
+        if ( ! empty( $removed_doc_ids ) && is_array( $removed_doc_ids ) ) {
+            $doc_ids_as_string = implode( ', ', $removed_doc_ids );
+        }
+
+        WP_CLI::success( 'Posts deleted successfully! Deleted doc_ids: ' . $doc_ids_as_string );
+
+        return true;
+    }
+
+    /**
+     * Get valid list of indexes.
+     * $post[0] = doc_id
+     * $post[1] = post_data with blog_id and post_id.
+     *
+     * @param array $posts An array of posts with doc_id[0], 
+     * @return array Return an array of posts.
+     */
+    public function get_valid_doc_id_indexes( $posts ) {
+
+        $doc_id_indexes = [];
+
+        // RediPress returns at first doc_id and after that the data.
+        if ( ! empty( $posts ) && is_array( $posts ) ) {
+            foreach ( $posts as $key => $post ) {
+
+                // Check if valid post and add doc_id index to the deleted $doc_id_indexes.
+                if ( ! empty( $post ) && is_array( $post ) ) {
+                    $doc_id_indexes[] = (int) $key - 1;
+                }
+            }
+        }
+
+        return $doc_id_indexes;
+    }
+
+    /**
+     * Delete index.
+     *
+     * @param [type] $doc_id
+     * @return void
+     */
+    protected function delete_index( $doc_id ) {
+
+        // Do the delete.
+        if ( is_string( $doc_id ) ) {
+
+            // Do the delete from index.
+            $this->client->raw_command(
+                'FT.DEL',
+                [
+                    $this->index,
+                    $doc_id,
+                    'DD',
+                ]
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Build where clause for the query.
+     *
+     * @param string $blog_id Blog id. 
+     * @param string $post_type Post type as a string.
+     * @param string $limit Limit.
+     * @return string Where clause as a string.
+     */
+    public function build_where( $args ) {
+
+        $where = '';
+
+        if ( ! empty( $args['post_type'] ) ) {
+            $where = '@post_type:' . $args['post_type'];
+        }
+
+        if ( ! empty( $args['blog_id'] ) ) {
+            $where = $where . ' @blog_id:(' . $args['blog_id'] . ')';
+        }
+
+        return $where;
+    }
+
+    /**
+     * Returns the minimum amount of parameters the command accepts.
+     *
+     * @return integer
+     */
+    public static function get_min_parameters() : int {
+        return 0;
+    }
+
+    /**
+     * Returns the maximum amount of parameters the command accepts.
+     *
+     * @return integer
+     */
+    public static function get_max_parameters() : int {
+        return 3;
+    }
+}

--- a/src/CLI/Delete.php
+++ b/src/CLI/Delete.php
@@ -49,8 +49,8 @@ class Delete implements Command {
             }
         }
 
-        // Default limit to 50.
-        $limit = $assoc_args['limit'] ?? '50';
+        // Default limit to 100.
+        $limit = $assoc_args['limit'] ?? '100';
 
         // Blog_id and post_type.
         if ( ! empty( $query_vars ) ) {

--- a/src/CLI/Delete.php
+++ b/src/CLI/Delete.php
@@ -68,7 +68,7 @@ class Delete implements Command {
      *
      * @param int $args The query args.
      * @param int $query_vars Query limit.
-     * @return bool
+     * @return boolean
      */
     public function delete_posts( $query_vars, $limit ) {
 
@@ -148,7 +148,7 @@ class Delete implements Command {
     /**
      * Delete index.
      *
-     * @param [type] $doc_id
+     * @param string $doc_id RediSearch doc_id.
      * @return void
      */
     protected function delete_index( $doc_id ) {
@@ -166,8 +166,6 @@ class Delete implements Command {
                 ]
             );
         }
-
-        return true;
     }
 
     /**
@@ -190,7 +188,8 @@ class Delete implements Command {
         $last_idx = count( $query_vars ) - 1;
         $idx      = 0;
 
-        // Implode query_vars.
+        // Loop through query_vars and
+        // add valid query_vars to the where clause.
         if ( is_array( $query_vars ) ) {
 
             foreach ( $query_vars as $key => $var ) {


### PR DESCRIPTION
Delete posts from index by blog_id and post_type.

Example usage.
`wp redipress delete --blog_id=1 post_type=test limit=1000`

This could be extended afterwards by changing the $allowed_args.
But this has been tested with blog_id and post_type parameters.

Limit defaults to 100 for now but it could be overridden.