### PR TITLE
Init indexes inside 'init' hook only if in WP CLI

### DIFF
--- a/src/RediPress.php
+++ b/src/RediPress.php
@@ -13,6 +13,9 @@ use Geniem\RediPressPlugin,
     Geniem\RediPress\Utility,
     Geniem\RediPress\Rest;
 
+// Require the external API functions
+require_once( __DIR__ . '/API.php' );
+
 /**
  * RediPress main class
  */
@@ -168,9 +171,6 @@ class RediPress {
             }
 
             $info = Utility::format( $raw_info );
-
-            // Require the external API functions
-            require_once( __DIR__ . '/API.php' );
 
             if ( (int) $info['num_docs'] === 0 ) {
                 $this->plugin->show_admin_error( sprintf( __( 'RediPress: Index "%s" is empty, consider running the indexing function.', 'redipress' ), $type ) );

--- a/src/RediPress.php
+++ b/src/RediPress.php
@@ -137,17 +137,25 @@ class RediPress {
             return false;
         }
         else {
-            // Initialize indexes
-            add_action( 'init', function() {
-                // We want post index anyway
-                $this->indexes['posts'] = new PostIndex( $this->connection );
 
-                if ( Settings::get( 'use_user_query' ) ) {
-                    $this->indexes['users'] = new UserIndex( $this->connection );
-                }
-            }, 1000 );
+            // Initialize indexes.
+            // Run initialization inside 'init' hook only if in WP CLI to avoid code execution order errors.
+            defined( 'WP_CLI' ) ? add_action( 'init', fn() => $this->init_indexes(), 1000 ) : $this->init_indexes();
 
             return true;
+        }
+    }
+
+    /**
+     * Initialize indexes.
+     *
+     * @return void
+     */
+    protected function init_indexes () {
+        $this->indexes['posts'] = new PostIndex( $this->connection );
+
+        if ( Settings::get( 'use_user_query' ) ) {
+            $this->indexes['users'] = new UserIndex( $this->connection );
         }
     }
 


### PR DESCRIPTION
- Fix code execution order errors when using `new WP_Query( ... )`