### PR TITLE
tax_query operator AND hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.7] - 2023-05-12
+
+### Fixed
+- Fixes tax_query `AND` operator.
+
 ## [2.0.6] - 2023-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.0.7] - 2023-05-12
 
 ### Fixed
-- Fixes tax_query `AND` operator.
+- Fixed tax_query `AND` operator.
 
 ## [2.0.6] - 2023-04-27
 
 ### Fixed
-- Fixes query argument `'orderby' => 'meta_value'`.
+- Fixed query argument `'orderby' => 'meta_value'`.
 
 ## [2.0.4] - 2023-02-08
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: RediPress
  * Plugin URI:  https://github.com/devgeniem/redipress
  * Description: A WordPress plugin that provides a blazing fast search engine and WP Query performance enhancements.
- * Version:     2.0.6
+ * Version:     2.0.7
  * Author:      Geniem
  * Author URI:  http://www.geniem.fi/
  * License:     GPL3

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -560,6 +560,9 @@ abstract class QueryBuilder {
      *
      * This function runs itself recursively if the query has multiple levels.
      *
+     * RediSearch documentation for tag queries:
+     * https://redis.io/docs/stack/search/reference/tags/
+     *
      * @param array   $query    The block to create the block from.
      * @param string  $operator Possible operator of the parent array.
      * @param boolean $prefix   Whether to prefix the field with taxonomy_ or not.
@@ -620,8 +623,6 @@ abstract class QueryBuilder {
 
                             // Note: if we are handling term conditions with AND operator
                             // we need to form the query like so (@taxonomy: {term1}) (@taxonomy: {term2})
-                            // wrapping these condditions would break the query logic.
-                            // https://redis.io/docs/stack/search/reference/tags/
                             $and_queries = [];
 
                             array_map( function( $term ) use ( $clause, $prefix, &$and_queries ) {

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -616,6 +616,16 @@ abstract class QueryBuilder {
                                 implode( '|', array_map( [ $this, 'enclose_in_quotes' ], (array) $clause['terms'] ) )
                             );
                         }
+                        if ( $clause['operator'] === 'AND' ) {
+
+                            array_map( function( $term ) use ( $clause, $prefix, &$queries ) {
+                                $queries[] = sprintf(
+                                    '(@%s:{%s})',
+                                    $prefix ? 'taxonomy_' . $clause['taxonomy'] : $clause['taxonomy'],
+                                    $term
+                                );
+                            }, (array) $clause['terms'] );
+                        }
                         elseif ( $clause['operator'] === 'NOT IN' ) {
                             $queries[] = sprintf(
                                 '-(@%s:{%s})',
@@ -635,6 +645,16 @@ abstract class QueryBuilder {
                                 $prefix ? 'taxonomy_slug_' . $clause['taxonomy'] : $clause['taxonomy'],
                                 implode( '|', array_map( [ $this, 'enclose_in_quotes' ], (array) $clause['terms'] ) )
                             );
+                        }
+                        elseif ( $clause['operator'] === 'AND' ) {
+
+                            array_map( function( $term ) use ( $clause, $prefix, &$queries ) {
+                                $queries[] = sprintf(
+                                    '(@%s:{%s})',
+                                    $prefix ? 'taxonomy_slug_' . $clause['taxonomy'] : $clause['taxonomy'],
+                                    $term
+                                );
+                            }, (array) $clause['terms'] );
                         }
                         elseif ( $clause['operator'] === 'NOT IN' ) {
                             $queries[] = sprintf(
@@ -682,6 +702,17 @@ abstract class QueryBuilder {
                                 implode( '|', (array) $clause['terms'] )
                             );
                         }
+                        // 2023.05.09: Added AND operator for taxonomy_id
+                        elseif ( $clause['operator'] === 'AND' ) {
+
+                            array_map( function( $term ) use ( $clause, &$queries ) {
+                                $queries[] = sprintf(
+                                    '(@taxonomy_id_%s:{%s})',
+                                    $clause['taxonomy'],
+                                    $term
+                                );
+                            }, (array) $clause['terms'] );
+                        }
                         elseif ( $clause['operator'] === 'NOT IN' ) {
                             $queries[] = sprintf(
                                 '-(@taxonomy_id_%s:{%s})',
@@ -705,6 +736,14 @@ abstract class QueryBuilder {
         usort( $queries, function( $a, $b ) {
             return ( substr( $a, 0, 1 ) === '-' ) ? 1 : 0;
         });
+
+        // Note: if we are handling term conditions with AND operator
+        // we need to form the query like so (@taxonomy: {term1}) (@taxonomy: {term2})
+        // wrapping these condditions would break the query logic.
+        // https://redis.io/docs/stack/search/reference/tags/
+        if ( $clause['operator'] === 'AND' ) {
+            return implode( ' ', $queries );
+        }
 
         // Compare the relation.
         if ( $relation === 'AND' ) {

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -618,13 +618,21 @@ abstract class QueryBuilder {
                         }
                         if ( $clause['operator'] === 'AND' ) {
 
-                            array_map( function( $term ) use ( $clause, $prefix, &$queries ) {
-                                $queries[] = sprintf(
+                            // Note: if we are handling term conditions with AND operator
+                            // we need to form the query like so (@taxonomy: {term1}) (@taxonomy: {term2})
+                            // wrapping these condditions would break the query logic.
+                            // https://redis.io/docs/stack/search/reference/tags/
+                            $and_queries = [];
+
+                            array_map( function( $term ) use ( $clause, $prefix, &$and_queries ) {
+                                $and_queries[] = sprintf(
                                     '(@%s:{%s})',
                                     $prefix ? 'taxonomy_' . $clause['taxonomy'] : $clause['taxonomy'],
                                     $term
                                 );
                             }, (array) $clause['terms'] );
+
+                            $queries[] = '(' . implode( ' ', $and_queries ) . ')';
                         }
                         elseif ( $clause['operator'] === 'NOT IN' ) {
                             $queries[] = sprintf(
@@ -648,13 +656,17 @@ abstract class QueryBuilder {
                         }
                         elseif ( $clause['operator'] === 'AND' ) {
 
-                            array_map( function( $term ) use ( $clause, $prefix, &$queries ) {
-                                $queries[] = sprintf(
-                                    '(@%s:{%s})',
+                            $and_queries = [];
+
+                            array_map( function( $term ) use ( $clause, $prefix, &$and_queries ) {
+                                $and_queries[] = sprintf(
+                                    '@%s:{%s}',
                                     $prefix ? 'taxonomy_slug_' . $clause['taxonomy'] : $clause['taxonomy'],
                                     $term
                                 );
                             }, (array) $clause['terms'] );
+
+                            $queries[] = '(' . implode( ' ', $and_queries ) . ')';
                         }
                         elseif ( $clause['operator'] === 'NOT IN' ) {
                             $queries[] = sprintf(
@@ -705,13 +717,16 @@ abstract class QueryBuilder {
                         // 2023.05.09: Added AND operator for taxonomy_id
                         elseif ( $clause['operator'] === 'AND' ) {
 
-                            array_map( function( $term ) use ( $clause, &$queries ) {
-                                $queries[] = sprintf(
-                                    '(@taxonomy_id_%s:{%s})',
+                            $and_queries = [];
+                            array_map( function( $term ) use ( $clause, &$and_queries ) {
+                                $and_queries[] = sprintf(
+                                    '@taxonomy_id_%s:{%s}',
                                     $clause['taxonomy'],
                                     $term
                                 );
                             }, (array) $clause['terms'] );
+
+                            $queries[] = '(' . implode( ' ', $and_queries ) . ')';
                         }
                         elseif ( $clause['operator'] === 'NOT IN' ) {
                             $queries[] = sprintf(
@@ -736,14 +751,6 @@ abstract class QueryBuilder {
         usort( $queries, function( $a, $b ) {
             return ( substr( $a, 0, 1 ) === '-' ) ? 1 : 0;
         });
-
-        // Note: if we are handling term conditions with AND operator
-        // we need to form the query like so (@taxonomy: {term1}) (@taxonomy: {term2})
-        // wrapping these condditions would break the query logic.
-        // https://redis.io/docs/stack/search/reference/tags/
-        if ( $clause['operator'] === 'AND' ) {
-            return implode( ' ', $queries );
-        }
 
         // Compare the relation.
         if ( $relation === 'AND' ) {


### PR DESCRIPTION
Hotfix for tax_query operator 'AND'.
RediSearch should handle tags with AND operator like so (example with two taxonomies with operator `AND` and `OR` relation)
```(@taxonomy1: {term1} @taxonomy1: {term2}) | (@taxonomy2: {term3} @taxonomy2: {term4})```
https://redis.io/docs/stack/search/reference/tags/