### PR TITLE
Update smalot/pdfparser to fix encoding errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### Fixed
+- Update smalot/pdfparser to fix encoding errors.
+
 ## [2.0.7] - 2023-05-12
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "predis/predis": "^1.1",
         "php": ">=7.3",
-        "smalot/pdfparser": "^0.16.2",
+        "smalot/pdfparser": "^0.19.0",
         "phpoffice/phpword": "^0.18"
     },
     "conflict": {


### PR DESCRIPTION
Unicode character f. ex. in string `+30  ̊C:ssa` throws a fatal error when indexing PDF files. Tested indexing the same file after updating `smalot/pdfparser` and no errors were thrown. There are newer major versions of `smalot/pdfparser` available, but didn't want to go through that rabbit hole here. The version updated now is the final version in `0.x.x` cycle.