### PR TITLE
RediPress now properly forwards queries with NOT EXISTS to MySQL if it cannot handle them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.11] - 2024-09-05
+
+### Fixed
+- RediPress now properly forwards queries with NOT EXISTS to MySQL if it cannot handle them.
+
 ## [2.0.10] - 2024-08-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.0.11] - 2024-09-05
+## [2.0.11] - 2024-09-06
 
 ### Fixed
 - RediPress now properly forwards queries with NOT EXISTS to MySQL if it cannot handle them.

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: RediPress
  * Plugin URI:  https://github.com/devgeniem/redipress
  * Description: A WordPress plugin that provides a blazing fast search engine and WP Query performance enhancements.
- * Version:     2.0.10
+ * Version:     2.0.11
  * Author:      Geniem
  * Author URI:  http://www.geniem.fi/
  * License:     GPL3

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -539,9 +539,9 @@ abstract class QueryBuilder {
     /**
      * WP_Query meta_query parameter.
      *
-     * @return string|null
+     * @return string
      */
-    protected function meta_query() : ?string {
+    protected function meta_query() : string {
         if ( ! empty( $this->meta_query ) ) {
             return $this->meta_query;
         }

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -559,7 +559,7 @@ abstract class QueryBuilder {
             return $query;
         }
         else {
-            return null;
+            return '';
         }
     }
 
@@ -1046,7 +1046,7 @@ abstract class QueryBuilder {
                 'NOT IN'      => 'not_in',
             ];
 
-            // Escape dashes from the values. To prevent numeric values from being escaped, 
+            // Escape dashes from the values. To prevent numeric values from being escaped,
             // meta_query's type attribute must be set to numeric data type.
             $clause['value'] = Utility::escape_value_by_meta_type( $clause['value'], $type );
 


### PR DESCRIPTION
Return empty string instead of NULL if wp_querys meta_query has NOT EXISTS compare.