### PR TITLE
Fix delete command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.12] - 2024-10-18
+
+### Fixed
+- Fix delete command.
+
 ## [2.0.11] - 2024-09-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.0.12] - 2024-10-18
+## [2.0.12] - 2024-10-21
 
 ### Fixed
 - Fix delete command.

--- a/README.md
+++ b/README.md
@@ -15,25 +15,33 @@ RediPress is also built with extensive amount of hooks and filters to customize 
 
 <!-- code_chunk_output -->
 
-- [Requirements](#requirements)
-- [Installation and initialization](#installation-and-initialization)
-- [Usage](#usage)
-  - [Extra parameters](#extra-parameters)
-    - [Weights](#weights)
-      - [Post types](#post-types)
-      - [Authors](#authors)
-      - [Taxonomy terms](#taxonomy-terms)
-      - [Meta values](#meta-values)
-    - [Fuzzy matching](#fuzzy-matching)
-    - [Multisite search](#multisite-search)
-- [Expanding](#expanding)
-  - [Adding custom fields](#adding-custom-fields)
-  - [Modifying the post object](#modifying-the-post-object)
-- [Third party plugins](#third-party-plugins)
-  - [Advanced Custom Fields](#advanced-custom-fields)
-  - [Polylang](#polylang)
-- [Troubleshooting](#troubleshooting)
-- [WP-CLI](#WP-CLI)
+- [RediPress](#redipress)
+- [Table of Contents](#table-of-contents)
+  - [Requirements](#requirements)
+  - [Installation and initialization](#installation-and-initialization)
+    - [Indexing multisite installations](#indexing-multisite-installations)
+  - [Usage](#usage)
+    - [Extra parameters](#extra-parameters)
+      - [Geolocation](#geolocation)
+        - [Sorting](#sorting)
+      - [Weights](#weights)
+        - [Post types](#post-types)
+        - [Authors](#authors)
+        - [Taxonomy terms](#taxonomy-terms)
+        - [Meta values](#meta-values)
+      - [Fuzzy matching](#fuzzy-matching)
+      - [Multisite search](#multisite-search)
+    - [Filters](#filters)
+      - [Query parts](#query-parts)
+  - [Expanding](#expanding)
+    - [Adding custom fields](#adding-custom-fields)
+    - [Modifying the post object](#modifying-the-post-object)
+  - [Third party plugins](#third-party-plugins)
+    - [Advanced Custom Fields](#advanced-custom-fields)
+    - [Polylang](#polylang)
+  - [Troubleshooting](#troubleshooting)
+  - [WP-CLI](#wp-cli)
+    - [command: wp redipress delete](#command-wp-redipress-delete)
 
 <!-- /code_chunk_output -->
 
@@ -328,12 +336,13 @@ If you run into problems you can try dropping all indexes by running `wp redipre
 
 ### command: wp redipress delete
 
-description: Delete posts from the index by the arguments.
-arguments:
+Delete posts from the index by the arguments.
+
+Arguments:
 - `document field:` Any field from the document that should match the given value.
 - `limit:` If not defined the default value is 100.
 
-example usage:
+Example usage:
 ```bash
-wp redipress delete --blog_id=1 --post_type=article --limit=500
+wp redipress delete posts --blog_id=1 --post_type=article --limit=500
 ```

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: RediPress
  * Plugin URI:  https://github.com/devgeniem/redipress
  * Description: A WordPress plugin that provides a blazing fast search engine and WP Query performance enhancements.
- * Version:     2.0.11
+ * Version:     2.0.12
  * Author:      Geniem
  * Author URI:  http://www.geniem.fi/
  * License:     GPL3

--- a/src/CLI/Delete.php
+++ b/src/CLI/Delete.php
@@ -5,6 +5,7 @@
 
 namespace Geniem\RediPress\CLI;
 
+use Geniem\RediPress\Redis\Client;
 use WP_CLI;
 
 /**
@@ -13,13 +14,24 @@ use WP_CLI;
 class Delete implements Command {
 
     /**
+     * RediPress wrapper for the Predis client
+     *
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Index name
+     *
+     * @var string
+     */
+    protected $index;
+
+    /**
      * Class constructor.
      */
     public function __construct() {
-
-        // Get RediPress settings.
-        $this->client = apply_filters( 'redipress/client', null );
-        $this->index  = \Geniem\RediPress\Settings::get( 'index' );
+        $this->client = \apply_filters( 'redipress/client', null );
     }
 
     /**
@@ -29,17 +41,18 @@ class Delete implements Command {
      * @param array $assoc_args The optional command parameters.
      * @return boolean
      */
-    public function run( array $args = [], array $assoc_args = [] ) : bool {
-
+    public function run( array $args = [], array $assoc_args = [] ): bool {
         // Default limit to 100.
         $limit = $assoc_args['limit'] ?? '100';
 
-        // Blog_id and post_type.
-        if ( ! empty( $assoc_args ) ) {
+        if ( count( $args ) === 1 ) {
+            $this->index = $args[0];
             return $this->delete_posts( $assoc_args, $limit );
         }
-
-        WP_CLI::error( 'RediPress: "delete" command doesn\'t accept more than one parameter.' );
+        elseif ( count( $args ) > 1 ) {
+            WP_CLI::error( 'RediPress: "delete" command does not accept more than one parameter.' );
+            return false;
+        }
 
         return false;
     }
@@ -47,13 +60,12 @@ class Delete implements Command {
     /**
      * Delete posts from the index.
      *
-     * @param int $args The query args.
-     * @param int $query_vars Query limit.
+     * @param array $args The query args.
+     * @param int   $limit Query limit.
      * @return boolean
      */
-    public function delete_posts( $query_vars, $limit ) {
-
-        $doc_ids = $this->get_doc_ids( $query_vars, $limit );
+    public function delete_posts( $args, $limit ) {
+        $doc_ids = $this->get_doc_ids( $args, $limit );
 
         $removed_doc_ids = [];
 
@@ -61,7 +73,7 @@ class Delete implements Command {
         // run the delete command in RediSearch index.
         if ( ! empty( $doc_ids ) && is_array( $doc_ids ) ) {
             foreach ( $doc_ids as $doc_id ) {
-                $this->delete_index( $doc_id );
+                $this->delete_from_index( $doc_id );
                 $removed_doc_ids[] = $doc_id;
             }
         }
@@ -83,11 +95,11 @@ class Delete implements Command {
     /**
      * Get the doc ids.
      *
-     * @param int $args The query args.
-     * @param int $query_vars Query limit.
+     * @param array $args The query args.
+     * @param int   $limit Query limit.
      * @return array An array of doc ids.
      */
-    protected function get_doc_ids( $query_vars, $limit ) {
+    protected function get_doc_ids( $args, $limit ) {
 
         // Get the posts.
         // Do the RediSearch query.
@@ -95,7 +107,7 @@ class Delete implements Command {
             'FT.SEARCH',
             [
                 $this->index,
-                $this->build_where( $query_vars ),
+                $this->build_where( $args ),
                 'RETURN',
                 1,
                 'post_id',
@@ -118,13 +130,11 @@ class Delete implements Command {
      * @param string $doc_id RediSearch doc_id.
      * @return void
      */
-    protected function delete_index( $doc_id ) {
-
-        // Do the delete.
+    protected function delete_from_index( $doc_id ) {
         if ( is_string( $doc_id ) ) {
-            // Do the delete from index.
+            // Delete post from the index.
             $this->client->raw_command(
-                'HDEL',
+                'DEL',
                 [
                     $this->index,
                     $doc_id,
@@ -166,7 +176,7 @@ class Delete implements Command {
                         $where = $where . ' ';
                     }
 
-                    $idx++;
+                    ++$idx;
                 }
             }
         }
@@ -179,8 +189,8 @@ class Delete implements Command {
      *
      * @return integer
      */
-    public static function get_min_parameters() : int {
-        return 0;
+    public static function get_min_parameters(): int {
+        return 1;
     }
 
     /**
@@ -188,7 +198,7 @@ class Delete implements Command {
      *
      * @return integer
      */
-    public static function get_max_parameters() : int {
-        return 3;
+    public static function get_max_parameters(): int {
+        return 1;
     }
 }

--- a/src/CLI/Delete.php
+++ b/src/CLI/Delete.php
@@ -45,6 +45,9 @@ class Delete implements Command {
         // Default limit to 100.
         $limit = $assoc_args['limit'] ?? '100';
 
+        // Remove the optional limit parameter, that should not be passed to the Redisearch query.
+        unset( $assoc_args['limit'] );
+
         if ( count( $args ) === 1 ) {
             $this->index = $args[0];
             return $this->delete_posts( $assoc_args, $limit );


### PR DESCRIPTION
`wp redipress delete` does not work with version 2.x. This commit fixes it. The index must be passed as the first (and only) argument. Also changed the actual command from `HDEL` to `DEL`, according to docs `HDEL` only targets single fields instead of the whole post.